### PR TITLE
Simply makes the crate `no_std` compatible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 //!     masks
 //! }
 //! ```
-
+#![no_std]
 
 /// A for loop that is usable in const contexts.
 /// 


### PR DESCRIPTION
Hi! I would like to use this crate for an embedded `no_std` project,  but it is currently not marked as `no_std` compatible, so it will not compile as a dependency.

The crate looks like it's basically just a macro, and the code it generates does not depend on the standard library or allocation at all, so it genuinely is `no_std` compatible.

This pull request just adds the single line to `lib.rs` to make it compatible with `no_std` projects. Adding this caused my `no_std` project to compile without an issue, and all tests for this crate still pass.

This should be a fully backward-compatible change as my understanding is that marking a crate `no_std` compatible does not affect anything when the standard library _is_ available. May want to add a note in the main crate documentation that it is `no_std` compatible, however, as this is a nice feature for projects that need it.

I hope you'll consider this change, and if there are any questions or concerns, let's discuss.

